### PR TITLE
Fix compilation and function with ClamAV 0.101.x

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -187,7 +187,19 @@ if test a"$clamav" = "ayes"; then
     AC_DEFINE(HAVE_LIBCLAMAV_095,1,[Define HAVE_LIBCLAMAV_095 if have clamav 0.95.x or newer])
     AC_MSG_RESULT(yes),
     )
+
+    #
+    # clamav dropped CL_SCAN_HEURISTIC_ENCRYPTED in 0.101 replacing it with
+    # CL_SCAN_HEURISTIC_ENCRYPTED_ARCHIVE and CL_SCAN_HEURISTIC_ENCRYPTED_DOC
     # restore flags  / clamav tests
+    AC_MSG_CHECKING([for HAVE_CL_SCAN_OPTIONS in clamav.h])
+    AC_TRY_COMPILE(
+    [#include <clamav.h>],
+    [struct cl_scan_options CLAMSCAN_OPTIONS = { 0, 0, 0, 0, 0 };],
+    AC_DEFINE(HAVE_CL_SCAN_OPTIONS,1,[Define HAVE_CL_SCAN_OPTIONS if have clamav 0.101.x or newer])
+    AC_MSG_RESULT(yes),
+    AC_MSG_RESULT(no),
+    )
     CFLAGS=$OLD_CFLAGS
 fi # if test a"$clamav" = "ayes";
 

--- a/services/virus_scan/clamav_mod.conf
+++ b/services/virus_scan/clamav_mod.conf
@@ -131,6 +131,33 @@ clamav_mod.MaxScanSize 100M
 # Default:
 #       clamav_mod.PhishingAlwaysBlockCloak off
 
+# TAG: clamav_mod.ProtectCCNumSSN
+# Format: clamav_mod.ProtectCCNumSSN on|off
+# Description:
+#	Enable the clamav data loss prevention (DLP) module which scans
+#	for credit card and SSN numbers. i.e. alert when detecting
+#	personal information.
+#	WARNING: This will break many government, banking and ecommerce
+#	sites. Use with Caution.
+# Default:
+#       clamav_mod.ProtectCCNumSSN off
+
+# TAG: clamav_mod.ProtectSSNNormal
+# Format: clamav_mod.ProtectSSNNormal on|off
+# Description:
+#	Search for [and alert when detecting] SSNs formatted as xx-yy-zzzz.
+#	Implies ProtectCCNumSSN on.
+# Default:
+#       clamav_mod.ProtectSSNNormal off
+
+# TAG: clamav_mod.ProtectSSNStripped
+# Format: clamav_mod.ProtectSSNStripped on|off
+# Description:
+#	Search for [and alert when detecting] SSNs formatted as xxyyzzzz.
+#	Implies ProtectCCNumSSN on.
+# Default:
+#       clamav_mod.ProtectSSNStripped off
+
 # TAG: clamav_mod.ReportVirusOnFailure
 # Format: clamav_mod.ReportVirusOnFailure on|off
 # Description:


### PR DESCRIPTION
0.101.x breaks the API in some ways. This fixes the problem. I have tested that this works with 0.101.x as available in Fedora. I have not tested with older versions.