### PR TITLE
Address HTML code escaping in url_check module.

### DIFF
--- a/services/url_check/Makefile.am
+++ b/services/url_check/Makefile.am
@@ -9,9 +9,9 @@ do_subst=sed -e 's%[@]SYSCONFDIR[@]%$(CONFIGDIR)%g' \
              -e 's%[@]PACKAGE_STRING[@]%$(PACKAGE_STRING)%g'
 
 srv_url_check_la_LIBADD = @MODULES_LIBADD@
-srv_url_check_la_CFLAGS= 
+srv_url_check_la_CFLAGS=
 srv_url_check_la_LDFLAGS=  -module -avoid-version
-srv_url_check_la_SOURCES = srv_url_check.c url_check_body.c request_filter.c
+srv_url_check_la_SOURCES = srv_url_check.c url_check_body.c request_filter.c htmlencode.c
 
 manpages = c-icap-mods-sguardDB.8
 manpages_src = $(manpages:.8=.8.in)
@@ -45,4 +45,4 @@ install-data-local:
 	for f in $(TMPLS); do  $(INSTALL) $(srcdir)/$$f $(DESTDIR)$(cicapdatadir)/templates/srv_url_check/en/; done
 
 
-EXTRA_DIST= sguardDB.h url_check_body.h request_filter.h makefile.w32 srv_url_check.def srv_url_check.conf $(TMPLS) $(manpages_src)
+EXTRA_DIST= sguardDB.h url_check_body.h request_filter.h makefile.w32 srv_url_check.def srv_url_check.conf htmlencode.h $(TMPLS) $(manpages_src)

--- a/services/url_check/htmlencode.c
+++ b/services/url_check/htmlencode.c
@@ -1,0 +1,126 @@
+/*
+ *  Copyright (C) 2021 Shawn Michael
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+struct sz_string {
+  char *data;
+  size_t size;
+  size_t buffsz;
+};
+
+struct sz_string *double_sz_string(struct sz_string *output) {
+    void *voidbuff;
+
+    voidbuff = realloc((void *)output->data, output->buffsz * 2);
+    if (voidbuff == NULL) {
+        perror("Error during realloc");
+        free(output->data);
+        free(output);
+        return(NULL);
+    }
+    // Blank the new chunk of RAM
+    output->data = (char *)voidbuff;
+    output->buffsz *= 2;
+
+    return(output);
+}
+
+char *htmlspecialchars(char *input, size_t len) {
+    size_t offset = 0;
+    char *replacement;  // Double duty as a temp var for constants and
+                        // the return value.
+    int copysize = 1;
+    struct sz_string *output;
+
+    if ((output = (struct sz_string *)malloc(sizeof(struct sz_string))) == NULL) {
+        perror("Error during initial malloc");
+        return(NULL);
+    }
+    // Set minimum buffer size to 256 bytes.  This prevents security errors
+    // later.  This size *MUST* be larger than the replacement string size
+    // for characters.  So if you change this it MUST be at least 6 for
+    // "&quot;"
+    // Excess here gets freed later with a realloc down to the correct size.
+    output->buffsz = 2 * len > 256 ? 2 * len : 256;
+    output->size = 0;
+    output->data = (char*)malloc(output->buffsz);
+    if (output->data == NULL) {
+        perror("Error during string malloc");
+        free((void*) output);
+        return(NULL);
+    }
+
+    for (offset = 0; offset < len; offset++) {
+        if (output->size > output->buffsz) {
+            if ((output = double_sz_string(output)) == NULL) {
+                perror("NULL found during double size");
+                return(NULL);
+            }
+        }
+
+        switch (input[offset]) {
+            case '&':
+                replacement = "&amp;";
+                copysize = 5;
+                break;
+            case '<':
+                replacement = "&lt;";
+                copysize = 4;
+                break;
+            case '>':
+                replacement = "&gt;";
+                copysize = 4;
+                break;
+            case '\'':
+                replacement = "&apos;";
+                copysize = 6;
+                break;
+            case '"':
+                replacement = "&quot;";
+                copysize = 6;
+                break;
+            default:
+                output->data[output->size++] = input[offset];
+                continue;
+        }
+
+        // Rest of loop only runs on a replacement being necessary.
+        if (output->size + copysize > output->buffsz) {
+            if ((output = double_sz_string(output)) == NULL) {
+                perror("Error during string malloc");
+                return(NULL);
+            }
+        }
+        memcpy((void *)(output->data + output->size), replacement, copysize);
+        output->size += copysize;
+    }
+
+    if ((replacement = realloc((void *)output->data, output->size + 1)) == NULL) {
+        // Unalbe to allocate null character
+        free(output->data);
+    } else {
+        replacement[output->size] = '\0';
+    }
+    free(output);
+    return(replacement);
+}
+
+

--- a/services/url_check/htmlencode.h
+++ b/services/url_check/htmlencode.h
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (C) 2021 Shawn Michael
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+
+char *htmlspecialchars(char *input, int size);

--- a/services/url_check/srv_url_check.c
+++ b/services/url_check/srv_url_check.c
@@ -1860,58 +1860,98 @@ static struct url_check_action *select_action(const char *action)
 /* Formating table functions */
 int fmt_srv_urlcheck_http_url(ci_request_t *req, char *buf, int len, const char *param)
 {
-    struct url_check_data *uc = ci_service_data(req);
-    int protosz = strnlen(protos[uc->httpinf.proto], 16);
-    int pathsz = strnlen(uc->httpinf.url, 1024);
+    struct url_check_data *uc;
+    int retval, pathsz;
+    char *uri;
+
+    uc = ci_service_data(req);
+    pathsz = strnlen(uc->httpinf.url, 1024);
+    uri = htmlspecialchars(uc->httpinf.url, pathsz);
     /*Do notwrite more than 512 bytes*/
-    return snprintf(buf, (len < 512? len:512), "%s://%s", htmlspecialchars(protos[uc->httpinf.proto], protosz) , htmlspecialchars(uc->httpinf.url, pathsz));
+    retval =  snprintf(buf, (len < 512? len:512), "%s://%s", protos[uc->httpinf.proto], uri));
+    if (uri)
+        free(uri);
+    return retval;
 }
 
 int fmt_srv_urlcheck_host(ci_request_t *req, char *buf, int len, const char *param)
 {
-    struct url_check_data *uc = ci_service_data(req);
-    int strsz = strnlen(uc->httpinf.host, 1024);
-    return snprintf(buf, len, "%s", htmlspecialchars(uc->httpinf.host, strsz));
+    struct url_check_data *uc;
+    char *host;
+    int retval, strsz;
+
+    uc = ci_service_data(req);
+    strsz = strnlen(uc->httpinf.host, 1024);
+    host = htmlspecialchars(uc->httpinf.host, strsz);
+    retval = snprintf(buf, len, "%s", host);
+    if (host)
+        free(host);
+    return retval;
 }
 
 int fmt_srv_urlcheck_matched_dbs(ci_request_t *req, char *buf, int len, const char *param)
 {
-    struct url_check_data *uc = ci_service_data(req);
-    int strsz = strnlen(uc->httpinf.host, 1024);
-    return snprintf(buf, len, "%s", htmlspecialchars(uc->match_info.matched_dbs, strsz));
+    struct url_check_data *uc;
+    int retval, strsz;
+    char *dbs;
+
+    uc = ci_service_data(req);
+    strsz = strnlen(uc->httpinf.host, 1024);
+    dbs = htmlspecialchars(uc->match_info.matched_dbs, strsz);
+    retval = snprintf(buf, len, "%s", dbs);
+    if (dbs)
+        free(dbs);
+    return retval;
 }
 
 int fmt_srv_urlcheck_blocked_db(ci_request_t *req, char *buf, int len, const char *param)
 {
-    struct url_check_data *uc = ci_service_data(req);
-    int dbsz = 0;
-    int subcatsz = 0;
+    struct url_check_data *uc;
+    int retval, dbsz, catsz;
+    char *db, *cat;
 
+    uc = ci_service_data(req);
     if (uc->match_info.action < 0)
         return 0;
+
     dbsz = strnlen(uc->match_info.action_db, 256);
+    db = htmlspecialchars(uc->match_info.action_db, dbsz);
     if (uc->match_info.last_subcat[0] != '\0') {
-        subcatsz = strnlen(uc->match_info.last_subcat, 256);
-        return snprintf(buf, len, "%s{%s}", htmlspecialchars(uc->match_info.action_db, dbsz), htmlspecialchars(uc->match_info.last_subcat, subcatsz));
+        catsz = strnlen(uc->match_info.last_subcat, 256);
+        cat = htmlspecialchars(uc->match_info.last_subcat, catsz);
+        retval = snprintf(buf, len, "%s{%s}", db, cat);
+        if (cat)
+            free(cat);
     } else {
-        return snprintf(buf, len, "%s", htmlspecialchars(uc->match_info.action_db, dbsz));
+        retval = snprintf(buf, len, "%s", db);
     }
+    if (db)
+        free(db);
+    return retval;
 }
 
 int fmt_srv_urlcheck_blocked_db_descr(ci_request_t *req, char *buf, int len, const char *param)
 {
     struct url_check_data *uc = ci_service_data(req);
-    int dbsz = 0;
-    int subcatsz = 0;
+    int retval, dbsz, catsz;
+    char *db, *cat;
+
     if (uc->match_info.action < 0)
         return 0;
     if (uc->match_info.action_db_descr == NULL)
         return fmt_srv_urlcheck_blocked_db(req, buf, len, param);
     dbsz = strnlen(uc->match_info.action_db_descr, 256);
+    db = htmlspecialchars(uc->match_info.action_db_descr, dbsz);
     if (uc->match_info.last_subcat[0] != '\0') {
-        subcatsz = strnlen(uc->match_info.last_subcat, 256);
-        return snprintf(buf, len, "%s{%s}", htmlspecialchars(uc->match_info.action_db_descr, dbsz), htmlspecialchars(uc->match_info.last_subcat, subcatsz));
+        catsz = strnlen(uc->match_info.last_subcat, 256);
+        cat = htmlspecialchars(uc->match_info.last_subcat, catsz);
+        retval = snprintf(buf, len, "%s{%s}", db, cat);
+        if (cat)
+            free(cat);
     } else {
-        return snprintf(buf, len, "%s", htmlspecialchars(uc->match_info.action_db_descr, dbsz));
+        retval = snprintf(buf, len, "%s", db);
     }
+    if (db)
+        free(db);
+    return retval;
 }

--- a/services/url_check/srv_url_check.c
+++ b/services/url_check/srv_url_check.c
@@ -1868,7 +1868,7 @@ int fmt_srv_urlcheck_http_url(ci_request_t *req, char *buf, int len, const char 
     pathsz = strnlen(uc->httpinf.url, 1024);
     uri = htmlspecialchars(uc->httpinf.url, pathsz);
     /*Do notwrite more than 512 bytes*/
-    retval =  snprintf(buf, (len < 512? len:512), "%s://%s", protos[uc->httpinf.proto], uri));
+    retval =  snprintf(buf, (len < 512? len:512), "%s://%s", protos[uc->httpinf.proto], uri);
     if (uri)
         free(uri);
     return retval;


### PR DESCRIPTION
The patch prevents a security error where HTML/Javascript injection can happen due to unescaped HTML characters in the URL.