### PR TITLE
virus_scan: error 500 when antivirus not available

### DIFF
--- a/services/virus_scan/virus_scan.c
+++ b/services/virus_scan/virus_scan.c
@@ -413,6 +413,7 @@ int virus_scan_check_preview_handler(char *preview_data, int preview_data_len,
      }
 
      if (!data->engine[0]) {
+         ci_stat_uint64_inc(AV_SCAN_FAILURES, 1);
          ci_debug_printf(1, "Antivirus engine is not available, returning error\n");
          return CI_ERROR;
      }

--- a/services/virus_scan/virus_scan.c
+++ b/services/virus_scan/virus_scan.c
@@ -413,8 +413,8 @@ int virus_scan_check_preview_handler(char *preview_data, int preview_data_len,
      }
 
      if (!data->engine[0]) {
-         ci_debug_printf(1, "Antivirus engine is not available, allow 204\n");
-         return CI_MOD_ALLOW204;
+         ci_debug_printf(1, "Antivirus engine is not available, returning error\n");
+         return CI_ERROR;
      }
 
      /*Compute the expected size, will be used by must_scanned*/


### PR DESCRIPTION
Basic patch to return an error when the antivirus is not available
See https://github.com/c-icap/c-icap-server/issues/36

I would also like that c-icap refuses to start when clamd_mod is enabled but clamd is down