### PR TITLE
Error/Pass logic on av engine not available

### DIFF
--- a/services/virus_scan/virus_scan.c
+++ b/services/virus_scan/virus_scan.c
@@ -411,8 +411,12 @@ int virus_scan_check_preview_handler(char *preview_data, int preview_data_len,
      }
 
      if (!data->engine[0]) {
-         ci_debug_printf(1, "Antivirus engine is not available, allow 204\n");
-         return CI_MOD_ALLOW204;
+        if (PASSONERROR) {
+            ci_debug_printf(1, "Antivirus engine is not available, allow 204 due to PassOnError\n");
+            return CI_MOD_ALLOW204;
+        }
+        ci_debug_printf(1, "Antivirus engine is not available.\n");
+        return CI_ERROR;
      }
 
      /*Compute the expected size, will be used by must_scanned*/


### PR DESCRIPTION
AV can fail silently and c-icap will happily pass all requests as 204, since there is config option for that it should be respected as per provided code.